### PR TITLE
[FIXED JENKINS-5492] Hide & encrypt Bind Password.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,6 +88,11 @@
             <id>repo.jenkins-ci.org</id>
             <url>http://repo.jenkins-ci.org/public/</url>
         </repository>
+        <repository>
+            <!-- Added this repository for ddsteps denpendency -->
+            <id>maven.wso2.org</id>
+            <url>http://maven.wso2.org/nexus/content/groups/wso2-public</url>
+        </repository>
     </repositories>
 
     <pluginRepositories>

--- a/pom.xml
+++ b/pom.xml
@@ -1,9 +1,9 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
-		<groupId>org.jvnet.hudson.plugins</groupId>
+		<groupId>org.jenkins-ci.plugins</groupId>
 		<artifactId>plugin</artifactId>
-		<version>1.377</version>
+		<version>1.436</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/src/main/java/com/mtvi/plateng/hudson/ldap/Configuration.java
+++ b/src/main/java/com/mtvi/plateng/hudson/ldap/Configuration.java
@@ -4,6 +4,7 @@
 
 package com.mtvi.plateng.hudson.ldap;
 
+import hudson.util.Secret;
 import org.apache.commons.lang.builder.ToStringBuilder;
 import org.apache.commons.lang.builder.ToStringStyle;
 
@@ -34,7 +35,7 @@ public class Configuration {
     /**
      * The password to use when binding to LDAP. Optional.
      */
-    private String bindPassword;
+    private Secret bindPassword;
 
     /**
      * The LDAP attribute which stores the user's email address. Typically
@@ -73,7 +74,7 @@ public class Configuration {
     }
 
     public String getBindPassword() {
-        return bindPassword;
+        return Secret.toString(bindPassword);
     }
 
     public String getEmailAttribute() {
@@ -128,7 +129,7 @@ public class Configuration {
     }
 
     public void setBindPassword(String bindPassword) {
-        this.bindPassword = bindPassword;
+        this.bindPassword = Secret.fromString(bindPassword);
     }
 
     public void setEmailAttribute(String emailAttribute) {

--- a/src/main/resources/com/mtvi/plateng/hudson/ldap/PluginImpl/config.jelly
+++ b/src/main/resources/com/mtvi/plateng/hudson/ldap/PluginImpl/config.jelly
@@ -10,7 +10,7 @@
       <f:textbox name="bindDN" value="${it.config.bindDN}"/>
     </f:entry>
     <f:entry title="${%Bind Password}">
-      <f:textbox name="bindPassword" value="${it.config.bindPassword}"/>
+      <f:password field="bindPassword" value="${it.config.bindPassword}"/>
     </f:entry>
     <f:entry title="${%Email Attribute}">
       <f:textbox name="emailAttribute" value="${it.config.emailAttribute}"/>

--- a/src/test/java/com/mtvi/plateng/hudson/ldap/BaseLdapSearchTestCase.java
+++ b/src/test/java/com/mtvi/plateng/hudson/ldap/BaseLdapSearchTestCase.java
@@ -7,7 +7,8 @@ package com.mtvi.plateng.hudson.ldap;
 import javax.naming.directory.SearchControls;
 import javax.naming.directory.SearchResult;
 
-import junit.framework.TestCase;
+import org.junit.After;
+import org.junit.Before;
 
 import com.mockobjects.naming.directory.MockAttribute;
 import com.mockobjects.naming.directory.MockAttributes;
@@ -15,7 +16,7 @@ import com.mockobjects.naming.directory.MockDirContext;
 import com.mockobjects.naming.directory.MockNamingEnumeration;
 import com.mtvi.plateng.testing.jndi.MockDirContextFactory;
 
-public abstract class BaseLdapSearchTestCase extends TestCase {
+public abstract class BaseLdapSearchTestCase {
     private MockDirContext mockContext;
     private MockNamingEnumeration mockResults;
     private MockAttributes attrs;
@@ -33,9 +34,8 @@ public abstract class BaseLdapSearchTestCase extends TestCase {
 
     }
 
-    @Override
-    protected void setUp() throws Exception {
-        super.setUp();
+    @Before
+    public void setUp() throws Exception {
         mockContext = MockDirContextFactory.getContext(getLDAPURL());
         System.out.println("in setup: " + mockContext);
         SearchControls ctrs = new TestSearchControls();
@@ -56,14 +56,13 @@ public abstract class BaseLdapSearchTestCase extends TestCase {
         mockContext.setupSearchResult(mockResults);
     }
 
-    @Override
-    protected void tearDown() throws Exception {
+    @After
+    public void tearDown() throws Exception {
         mockContext.verify();
         attrs.verify();
         attr.verify();
         mockResults.verify();
         MockDirContextFactory.removeContext(getLDAPURL());
-        super.tearDown();
     }
 
 }

--- a/src/test/java/com/mtvi/plateng/hudson/ldap/LdapSearchTest.java
+++ b/src/test/java/com/mtvi/plateng/hudson/ldap/LdapSearchTest.java
@@ -4,10 +4,19 @@
 
 package com.mtvi.plateng.hudson.ldap;
 
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
 import com.mtvi.plateng.testing.jndi.MockDirContextFactory;
 
 public class LdapSearchTest extends BaseLdapSearchTestCase {
+    @Rule public JenkinsRule j = new JenkinsRule();
 
+    @Test
     public void testSearchUser() throws Exception {
         Configuration config = new Configuration();
         config.setServer(getLDAPURL());
@@ -21,6 +30,7 @@ public class LdapSearchTest extends BaseLdapSearchTestCase {
         assertEquals("mail@test.com", resolver.findMailAddressFor("testuser"));
     }
 
+    @Test
     public void testSearchUserWithAuth() throws Exception {
         Configuration config = new Configuration();
         config.setServer(getLDAPURL());


### PR DESCRIPTION
Hide the Bind Password by changing text field to password field in config.jelly.
Encrypt the Bind Password by changing password type from String to Secret.
Upgrade the core version to 1.436 in pom.xml file to support JDK 7 or higher and
to use jenkinsRule in the LdapSearchTest.
Add jenkinsRule and annotations for the tests to solve the NullPointer Exception
caused by password type changing.
When the user upgrades the plugin, they need to click save in the config page in
order to encrypt the password on the file system.
